### PR TITLE
[JENKINS-30965] Add missing config.jelly for googleUserInfo.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/googlelogin/GoogleUserInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googlelogin/GoogleUserInfo/config.jelly
@@ -1,0 +1,3 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+</j:jelly>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-30965

Prevents an error showing in the user configuration page.

@reviewbybees 