### PR TITLE
Escape ampersand in HTML

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm/help.html
@@ -7,7 +7,7 @@
      <ol>
          <li>Login to the <a href="https://console.developers.google.com/">Google Developers Console</a></li>
          <li>Create a new project</li>
-         <li>Under APIs & Auth -> Credentials, Create a new Client ID</li>
+         <li>Under APIs &amp; Auth -> Credentials, Create a new Client ID</li>
          <li>The application type should be "Web Application"</li>
          <li>The authorized redirect URLs should contain ${JENKINS_ROOT_URL}/securityRealm/finishLogin</li>
          <li>Enter the created Client Id and secret into the fields below.</li>


### PR DESCRIPTION
Ampersands should always be escaped in HTML. Refer to http://docs.webplatform.org/wiki/guides/the_basics_of_html#Character_references for details