### PR TITLE
Remove leading and trailing spaces from domain

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
@@ -222,7 +222,8 @@ public class GoogleOAuth2SecurityRealm extends SecurityRealm {
         }
         StringTokenizer tokenizer = new StringTokenizer(domain, ",");
         while (tokenizer.hasMoreElements()) {
-            if (tokenizer.nextToken().equals(tokenDomain)) {
+            String domainToTest = tokenizer.nextToken().trim();
+            if (domainToTest.equals(tokenDomain)) {
                 return true;
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealmTest.java
@@ -28,7 +28,7 @@ public class GoogleOAuth2SecurityRealmTest {
         assertTrue(instance.isDomainValid("acme.com"));
         assertFalse(instance.isDomainValid("mycompany.com"));
     }
-    
+
     @Test
     public void validSingleDomain() throws IOException {
         GoogleOAuth2SecurityRealm instance = setupInstanceWithDomains("acme.com");
@@ -38,14 +38,21 @@ public class GoogleOAuth2SecurityRealmTest {
 
     @Test
     public void validTwoDomains() throws IOException {
-        GoogleOAuth2SecurityRealm instance = setupInstanceWithDomains("acme.com","mycompany.com");
+        GoogleOAuth2SecurityRealm instance = setupInstanceWithDomains("acme.com,mycompany.com");
         assertTrue(instance.isDomainValid("acme.com"));
         assertTrue(instance.isDomainValid("mycompany.com"));
     }
 
-    private GoogleOAuth2SecurityRealm setupInstanceWithDomains(String... domains) throws IOException {
+    @Test
+    public void validTwoDomainsWithLeadingSpaces() throws IOException {
+        GoogleOAuth2SecurityRealm instance = setupInstanceWithDomains("acme.com, mycompany.com");
+        assertTrue(instance.isDomainValid("acme.com"));
+        assertTrue(instance.isDomainValid("mycompany.com"));
+    }
+
+    private GoogleOAuth2SecurityRealm setupInstanceWithDomains(String domains) throws IOException {
         String clientId = "clientId";
         String clientSecret = "clientSecret";
-        return new GoogleOAuth2SecurityRealm(clientId, clientSecret, StringUtils.join(domains,','));
+        return new GoogleOAuth2SecurityRealm(clientId, clientSecret, domains);
     }
 }


### PR DESCRIPTION
As at Jenkins "Google Apps Domain" configuration there are no
specification about the pattern expected, leading and trailing spaces
should be excluded, mostly when multiples domains are set.

Before the change, "foo@bar.com, bar@example.com" whould not be
accepted. Now it removes the leading space and accept the domain.

I also changed the tests to use a string the the comma separated string,
in this way tests and jenkins interface get more similar.