### PR TITLE
Remove negate of Util.isSafeToRedirectTo() given from should only be used if it is safe.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
@@ -187,9 +187,9 @@ public class GoogleOAuth2SecurityRealm extends SecurityRealm {
     @Restricted(DoNotUse.class) // stapler only
     public HttpResponse doCommenceLogin(StaplerRequest request, @QueryParameter String from,  @Header("Referer") final String referer) throws IOException {
         final String redirectOnFinish;
-        if (from != null && ! Util.isSafeToRedirectTo(from)) {
+        if (from != null && Util.isSafeToRedirectTo(from)) {
             redirectOnFinish = from;
-        } else if (referer != null && ! Util.isSafeToRedirectTo(referer)) {
+        } else if (referer != null && Util.isSafeToRedirectTo(referer)) {
             redirectOnFinish = referer;
         } else {
             redirectOnFinish = getRootURL();


### PR DESCRIPTION
When `from` is safe to redirect, it should be set as `redirectOnFinish`. Current logic will set `redirectOnFinish` to `from` when it is not safe to redirect.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
