### PR TITLE
Fix `getPostLogOutUrl` to include `contextPath`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
@@ -177,7 +177,7 @@ public class GoogleOAuth2SecurityRealm extends SecurityRealm {
 
     @Override
     protected String getPostLogOutUrl(StaplerRequest req, Authentication auth) {
-        return "securityRealm/loggedOut";
+        return req.getContextPath() + "/securityRealm/loggedOut";
     }
 
     /**


### PR DESCRIPTION
@jtnord noticed a regression when using this security realm in conjunction with CloudBees CI: when configuring single-sign on from a controller to Operations Center, where O.C. is in turn doing SSO to Google, as of [a new O.C. SSO implementation](https://docs.cloudbees.com/docs/release-notes/latest/cloudbees-ci/modern-cloud-platforms/2.401.2.3#_resolved_issues), if you logged out from the controller you could be taken to a bogus URL `https://…/cjoc/operations-center-openid/securityRealm/loggedOut` which was a 404. This was because `Jenkins.doLogout` was redirecting to `securityRealm/loggedOut` relative to a URI `/cjoc/operations-center-openid/logout` (rather than the more common `/cjoc/logout`). As [hinted at by Javadoc](https://javadoc.jenkins.io/hudson/security/SecurityRealm.html#getPostLogOutUrl2(org.kohsuke.stapler.StaplerRequest,org.springframework.security.core.Authentication)), this method expects the return value to be prefixed by the context path (the default value is `req.getContextPath() + "/"`), which `GoogleOAuth2SecurityRealm` was neglecting to do. Reproduced bug and verified fix using a Kind cluster running CI behind ngrok.