### PR TITLE
Use GitHub as source of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-google-login
-============
+Google Login Plugin
+==================
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/google-login.svg)](https://plugins.jenkins.io/google-login)
 
 A Jenkins plugin which lets you login to Jenkins with your Google account. Also allows you to restrict access
 to accounts in a given Google Apps domain.
@@ -16,3 +17,7 @@ Instructions to create the Client ID and Secret:
  1. The application type should be "Web Application"
  1. The authorized redirect URLs should contain ${JENKINS_ROOT_URL}/securityRealm/finishLogin
  1. Enter the created Client ID and secret in the Security Realm Configuration
+
+## Version history
+For recent versions see [GitHub releases](https://github.com/jenkinsci/google-login-plugin/releases),
+for versions prior to 1.5 see [the changelog](CHANGELOG.md).

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
 
   <name>Google Login Plugin</name>
-  <url>https://wiki.jenkins.io/display/JENKINS/Google+Login+Plugin</url>
+  <url>https://github.com/jenkinsci/google-login-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
Use GitHub for docs, because Jenkins wiki is dead and for this plugin was just linking to GH anyway.

### Testing done
N/A

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
